### PR TITLE
Make mailbox struct members public

### DIFF
--- a/Sources/SwiftEmailValidator/EmailSyntaxValidator.swift
+++ b/Sources/SwiftEmailValidator/EmailSyntaxValidator.swift
@@ -18,9 +18,9 @@ import SwiftPublicSuffixList
 public final class EmailSyntaxValidator {
     
     public struct Mailbox {
-        let email: String
-        let localPart: LocalPart
-        let host: Host
+        public let email: String
+        public let localPart: LocalPart
+        public let host: Host
 
         public enum LocalPart: Equatable {
             case dotAtom(String)


### PR DESCRIPTION
This marks the mailbox struct members as public so they can be accessed outside the package. 

Otherwise trying to access members like .host returned from a call to EmailSyntaxValidator.mailbox(from:) gives a compile error about them being internal in Xcode 15.3.